### PR TITLE
Add pin support to SPP initialization

### DIFF
--- a/BTSPP.cpp
+++ b/BTSPP.cpp
@@ -420,7 +420,7 @@ bool check_null_address (esp_bd_addr_t address) {
 	return true;
 }
 
-static bool _init_bt (const char* deviceName)
+static bool _init_bt (const char* deviceName, esp_bt_pin_code_t pin_code, uint8_t pin_length)
 {
 	if (!_spp_event_group) {
 		_spp_event_group = xEventGroupCreate ();
@@ -493,6 +493,7 @@ static bool _init_bt (const char* deviceName)
 	}
 
 	if (!bt_role) { // If master
+	    esp_bt_gap_set_pin(ESP_BT_PIN_TYPE_FIXED, pin_length, pin_code);
 		if (check_null_address (peer_bdaddress)) {
 			if ((esp_bt_gap_register_callback (esp_bt_gap_cb)) != ESP_OK) {
 				log_e ("GAP register failed");
@@ -591,7 +592,7 @@ BluetoothSerial::~BluetoothSerial (void)
 	_stop_bt ();
 }
 
-bool BluetoothSerial::begin (String localName, esp_spp_role_t role, String bda_name, esp_bd_addr_t destAddress)
+bool BluetoothSerial::begin (String localName, esp_spp_role_t role, String bda_name, esp_bd_addr_t destAddress, esp_bt_pin_code_t pin_code, uint8_t pin_length)
 {
 	if (localName.length ()) {
 		local_name = localName;
@@ -623,7 +624,7 @@ bool BluetoothSerial::begin (String localName, esp_spp_role_t role, String bda_n
 		}
 	}
 
-	return _init_bt (local_name.c_str ());
+	return _init_bt (local_name.c_str (), pin_code, pin_length);
 }
 
 int BluetoothSerial::available (void)

--- a/BTSPP.h
+++ b/BTSPP.h
@@ -22,6 +22,7 @@
 #include "Arduino.h"
 #include "Stream.h"
 #include <esp_spp_api.h>
+#include <esp_gap_bt_api.h>
 
 class BluetoothSerial: public Stream
 {
@@ -30,7 +31,7 @@ class BluetoothSerial: public Stream
         BluetoothSerial(void);
         ~BluetoothSerial(void);
 
-		bool begin (String localName = String (), esp_spp_role_t role = ESP_SPP_ROLE_SLAVE, String bda_name = String (), esp_bd_addr_t destAddress = 0);
+		bool begin (String localName = String (), esp_spp_role_t role = ESP_SPP_ROLE_SLAVE, String bda_name = String (), esp_bd_addr_t destAddress = 0, esp_bt_pin_code_t pin_code = 0, uint8_t pin_length = 0);
         int available(void);
         int peek(void);
         bool hasClient(void);


### PR DESCRIPTION
Adds support for supplying a fixed pin to the `begin` method, which is then passed on to the SPP initialization routine